### PR TITLE
Solr 6 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>com.englishtown.vertx</groupId>
         <artifactId>oss-parent-vertx</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <properties>
-        <solrj.version>5.2.1</solrj.version>
-        <vertx.hk2.version>2.1.0</vertx.hk2.version>
+        <solrj.version>6.2.1</solrj.version>
+        <vertx.hk2.version>2.4.0</vertx.hk2.version>
 
         <!--Vert.x codegen does not play nice with maven-compiler-plugin 3.2-->
         <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>

--- a/src/main/java/com/englishtown/vertx/solr/impl/DefaultVertxSolrClient.java
+++ b/src/main/java/com/englishtown/vertx/solr/impl/DefaultVertxSolrClient.java
@@ -10,7 +10,6 @@ import io.vertx.core.json.JsonObject;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.impl.HttpClientUtil;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
@@ -80,7 +79,7 @@ public class DefaultVertxSolrClient implements VertxSolrClient {
         params.remove(HttpClientUtil.PROP_BASIC_AUTH_USER);
         params.remove(HttpClientUtil.PROP_BASIC_AUTH_PASS);
 
-        URI uri = URI.create(baseUrl + path + ClientUtils.toQueryString(params, false));
+        URI uri = URI.create(baseUrl + path + params.toQueryString());
         int port = uri.getPort() > 0 ? uri.getPort() : ("https".equals(uri.getScheme()) ? 443 : 80);
 
         HttpClientRequest httpRequest = httpClient.request(HttpMethod.GET, port, uri.getHost(), uri.getPath() + "?" + uri.getQuery());

--- a/src/main/java/com/englishtown/vertx/solr/streams/impl/BufferJsonWriteStream.java
+++ b/src/main/java/com/englishtown/vertx/solr/streams/impl/BufferJsonWriteStream.java
@@ -29,6 +29,11 @@ public class BufferJsonWriteStream implements WriteStream<JsonObject> {
     }
 
     @Override
+    public void end() {
+        stream.end();
+    }
+
+    @Override
     public WriteStream<JsonObject> setWriteQueueMaxSize(int maxSize) {
         stream.setWriteQueueMaxSize(maxSize);
         return this;

--- a/src/test/java/com/englishtown/vertx/solr/integration/SolrPumpIntegrationTest.java
+++ b/src/test/java/com/englishtown/vertx/solr/integration/SolrPumpIntegrationTest.java
@@ -47,6 +47,11 @@ public class SolrPumpIntegrationTest extends SolrIntegrationTestBase {
             }
 
             @Override
+            public void end() {
+
+            }
+
+            @Override
             public WriteStream<JsonObject> setWriteQueueMaxSize(int maxSize) {
                 return this;
             }


### PR DESCRIPTION
I have made the small change to the library so it can work with `solrj:6.2.1`. 
The change in the `DefaultVertxSolrClient.java` is necessary to use `solrj:6.2.1` (in fact any solrj >= 5.4.0) and it is due to the `ClientUtils.toQueryString(SolrParams solrParams, bool xml)` method moved to the `SolrParams.toQueryString()` in `solrj:5.4.0`. 

Integration tests work fine against solr 6.2.1 instance ( tested against solr:6.2.1-alpine docker image), after the following steps
- create `collection1` core
- add at least 1 document to `collection1`
- update `config.json` with the solr url

additionally updated other dependencies to the latest versions